### PR TITLE
bugfix - return array if found in deepTranslate

### DIFF
--- a/lib/deep-translate.js
+++ b/lib/deep-translate.js
@@ -6,7 +6,7 @@ module.exports = options => {
   const translate = options.translate || _.identity;
   function deepTranslate(key) {
     let translated = translate(key);
-    if (_.isObject(translated)) {
+    if (_.isObject(translated) && !Array.isArray(translated)) {
       translated = _.reduceRight(translated, (prev, item, tKey) => {
         let translationPath = key + '.' + tKey;
         let result;

--- a/lib/deep-translate.js
+++ b/lib/deep-translate.js
@@ -6,11 +6,11 @@ module.exports = options => {
   const translate = options.translate || _.identity;
   function deepTranslate(key) {
     let translated = translate(key);
-    if (_.isObject(translated) && !Array.isArray(translated)) {
+    if (_.isPlainObject(translated)) {
       translated = _.reduceRight(translated, (prev, item, tKey) => {
         let translationPath = key + '.' + tKey;
         let result;
-        if (_.isObject(item) && this.sessionModel) {
+        if (_.isPlainObject(item) && this.sessionModel) {
           let value = this.sessionModel.get(tKey);
           if (value) {
             value = value.toString();

--- a/test/lib/deep-translate.js
+++ b/test/lib/deep-translate.js
@@ -54,7 +54,11 @@ describe('deepTranslate middleware', () => {
             'value-3': '3'
           }
         }
-      }
+      },
+      array: [
+        'value-1',
+        'value-2'
+      ]
     };
     next = sinon.stub();
     middleware = deepTranslate({
@@ -99,6 +103,10 @@ describe('deepTranslate middleware', () => {
     req.sessionModel.get.withArgs('dependent-field-1').returns('correct-value');
     req.sessionModel.get.withArgs('dependent-field-2').returns('correct-value');
     req.translate('another-field.header').should.be.equal('This should be looked up');
+  });
+
+  it('returns array if looked up', () => {
+    req.translate('array').should.be.an('array');
   });
 
   describe('Multi value fields', () => {


### PR DESCRIPTION
As an array is an object, they were being picked up by the deep translate middleware. Arrays should be returned as they are for multi line text