### PR TITLE
Fix vulnerability that allows redirection to malicious sites

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -31,8 +31,8 @@ module.exports = (options) => {
     } else {
       res.cookie(cookieName, 1);
 
-      let redirectURL =  (req.originalUrl && req.originalUrl.match(/^\/[^\/\\]/)) ?
-         new URI(req.originalUrl).addQuery(encodeURIComponent(paramName)) : '/'
+      let redirectURL = (req.originalUrl && req.originalUrl.match(/^\/[^\/\\]/)) ?
+         new URI(req.originalUrl).addQuery(encodeURIComponent(paramName)) : '/';
 
       res.redirect(redirectURL.toString());
     }

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -30,7 +30,10 @@ module.exports = (options) => {
       next(err, req, res, next);
     } else {
       res.cookie(cookieName, 1);
-      let redirectURL = new URI(req.originalUrl).addQuery(encodeURIComponent(paramName));
+
+      let redirectURL =  (req.originalUrl && req.originalUrl.match(/^\/[^\/\\]/)) ?
+         new URI(req.originalUrl).addQuery(encodeURIComponent(paramName)) : '/'
+
       res.redirect(redirectURL.toString());
     }
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-middleware",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "description": "A collection of commonly used HOF middleware",
   "main": "index.js",
   "license": "GPL-2.0",

--- a/test/lib/cookies.js
+++ b/test/lib/cookies.js
@@ -80,6 +80,15 @@ describe('cookies', () => {
       next.should.have.been.calledWith(err, req, res, next);
     });
 
+    it('redirects to self when there are no cookies and there is am attempt to redirect to malicious site', () => {
+      req = httpMock.createRequest({
+        method: 'GET',
+        url: '//bbc.co.uk',
+      });
+      middleware(req, res);
+      res.redirect.should.have.been.calledWith('/');
+    });
+
     it('does not raise an error when is a default healthcheck url', () => {
       req.cookies = {};
       req.query = {


### PR DESCRIPTION
What
Fix vulnerability that allows redirection to malicious sites

Why
Applications using this library could be vulnerable to a redirection exploit where an attacker can use a Home Office page to redirect someone to their malicious site

How
Ensure URLs are relative paths – i.e. they start with a single / character. Absolute URLs starting with // will be rejected.

Test
Tested locally by linking new version of hot-middleware to GRO 